### PR TITLE
Release: v0.1.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
       - run:
           name: Create release tag
           command: |
-            poetry run peltak release tag -m "$(potery run peltak changelog)"
+            poetry run peltak release tag -m "$(poetry run peltak changelog)"
             git push origin v$(poetry run peltak version --porcelain)
 
   gh-pages:

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,9 @@ mappr
     :target: https://codecov.io/gh/novopl/mappr
 
 .. image:: https://img.shields.io/badge/type_checked-mypy-informational.svg
+
 .. image:: https://img.shields.io/badge/License-Apache2-blue.svg
+
 .. image:: https://circleci.com/gh/novopl/mappr.svg?style=shield
     :target: https://circleci.com/gh/novopl/mappr
 .. readme_badges_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,3 +158,14 @@ command_file = "ops/scripts/docs.sh.j2"
     name = [ "--run-doctests" ]
     about = "Also run all doctests."
     is_flag = true
+
+
+[tool.peltak.scripts.pr-release]
+root_cli = true
+about = "Create PR for the current release branch"
+command = """
+gh pr create \
+    --repo novopl/mappr \
+    --title "Release: v$(peltak version --porcelain)" \
+    --body "$(peltak changelog)"
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mappr"
-version = "0.1.7"
+version = "0.1.8"
 description = ""
 authors = ["Mateusz Klos <novopl@gmail.com>"]
 repository = "https://github.com/novopl/mappr"

--- a/src/mappr/__init__.py
+++ b/src/mappr/__init__.py
@@ -8,4 +8,4 @@ from .iterators import field_iterator, iter_fields              # noqa: F401
 from .mappers import map_directly, set_const, use_default       # noqa: F401
 from .types import FieldIterator, MappingFn, ConverterFn        # noqa: F401
 
-__version__ = '0.1.7'
+__version__ = '0.1.8'


### PR DESCRIPTION
v0.1.8
======


Features
--------

- Add handy `peltak pr-release` command to create release PR quickly. Will
  create a title with current version: `Release: vX.X.X’ and put the result of
  `peltak changelog` into the body.