### PR TITLE
Release: v0.1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: novopl/python37
+      - image: novopl/python36
     steps:
       - checkout
       - restore_cache:
@@ -66,7 +66,7 @@ jobs:
 
   release:
     docker:
-      - image: novopl/python37
+      - image: novopl/python36
     steps:
       - checkout
       - restore_cache:
@@ -108,7 +108,7 @@ jobs:
 
   gh-pages:
     docker:
-      - image: novopl/python37
+      - image: novopl/python36
     steps:
       - checkout
       - restore_cache:

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@
                 :target: https://codecov.io/gh/novopl/mappr
 .. |mypy| image:: https://img.shields.io/badge/type_checked-mypy-informational.svg
 .. |license| image:: https://img.shields.io/badge/License-Apache2-blue.svg
-.. |py_ver| image:: https://img.shields.io/badge/python-3.7+-blue.svg
+.. |py_ver| image:: https://img.shields.io/badge/python-3.6+-blue.svg
 .. |nbsp| unicode:: 0xA0
 
 .. readme_badges_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mappr"
-version = "0.1.19"
+version = "0.1.20"
 description = ""
 authors = ["Mateusz Klos <novopl@gmail.com>"]
 repository = "https://github.com/novopl/mappr"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,10 @@ tag_format = '{tag}:'
     tag = 'dev'
     header = 'Dev tasks'
 
+    [[tool.peltak.changelog.tags]]
+    tag = 'refactor'
+    header = 'Refactored'
+
 
 [tool.peltak.version]
 files = [

--- a/src/mappr/__init__.py
+++ b/src/mappr/__init__.py
@@ -8,4 +8,4 @@ from .iterators import field_iterator, iter_fields              # noqa: F401
 from .mappers import map_directly, set_const, use_default       # noqa: F401
 from .types import FieldIterator, MappingFn, ConverterFn        # noqa: F401
 
-__version__ = '0.1.19'
+__version__ = '0.1.20'

--- a/src/mappr/conversion.py
+++ b/src/mappr/conversion.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any, List, Optional, Type, TypeVar
 
 from . import exc, iterators, mappers, types
@@ -7,11 +6,17 @@ from . import exc, iterators, mappers, types
 T = TypeVar('T')
 
 
-@dataclasses.dataclass
 class TypeConverter:
-    src_type: Type
-    dst_type: Type
-    mapping: types.FieldMapping = dataclasses.field(default_factory=dict)
+    def __init__(
+        self,
+        src_type: Type,
+        dst_type: Type,
+        *,
+        mapping: Optional[types.FieldMapping] = None
+    ):
+        self.src_type = src_type
+        self.dst_type = dst_type
+        self.mapping = mapping or {}
 
     def convert(self, src_obj: Any) -> Any:
         values = {}

--- a/src/mappr/integrations/dataclasses.py
+++ b/src/mappr/integrations/dataclasses.py
@@ -1,0 +1,11 @@
+import dataclasses
+from typing import Type
+
+from mappr import types
+from mappr.iterators import field_iterator
+
+
+@field_iterator(test=lambda cls: dataclasses.is_dataclass(cls))
+def dataclass_iter_fields(model_cls: Type) -> types.FieldIterator:
+    for field in dataclasses.fields(model_cls):
+        yield field.name

--- a/src/mappr/integrations/pydantic.py
+++ b/src/mappr/integrations/pydantic.py
@@ -1,0 +1,12 @@
+from typing import cast, Type
+
+import pydantic
+
+from mappr import types
+from mappr.iterators import field_iterator
+
+
+@field_iterator(test=lambda cls: issubclass(cls, pydantic.BaseModel))
+def pydantic_iter_fields(model_cls: Type) -> types.FieldIterator:
+    pydantic_model = cast(pydantic.BaseModel, model_cls)
+    yield from pydantic_model.__fields__.keys()

--- a/src/mappr/integrations/sqlalchemy.py
+++ b/src/mappr/integrations/sqlalchemy.py
@@ -1,0 +1,9 @@
+from typing import Type
+
+from mappr import types
+from mappr.iterators import field_iterator
+
+
+@field_iterator(test=lambda cls: hasattr(cls, '__table__'))
+def sa_model_iter_fields(model_cls: Type) -> types.FieldIterator:
+    yield from model_cls.__table__.columns.keys()

--- a/src/mappr/iterators.py
+++ b/src/mappr/iterators.py
@@ -8,7 +8,7 @@ g_field_iterators: List[types.FieldIter] = []
 
 def field_iterator(test=types.TestFn):
     def decorator(fn: Callable[[Any], types.FieldIterator]):
-        g_field_iterators.append(types.FieldIter(test=test, iter=fn))
+        g_field_iterators.append(types.FieldIter(test=test, iter_factory=fn))
         return fn
     return decorator
 

--- a/src/mappr/iterators.py
+++ b/src/mappr/iterators.py
@@ -1,5 +1,4 @@
-import dataclasses
-from typing import Any, Callable, cast, List, Optional, Type
+from typing import Any, Callable, List, Optional, Type
 
 from . import types
 
@@ -27,27 +26,19 @@ def _find_field_iter(any_cls: Type) -> Optional[types.FieldIter]:
     )
 
 
-@field_iterator(test=lambda cls: dataclasses.is_dataclass(cls))
-def _dataclass_iter_fields(model_cls: Type) -> types.FieldIterator:
-    for field in dataclasses.fields(model_cls):
-        yield field.name
-
-
-@field_iterator(test=lambda cls: hasattr(cls, '__table__'))
-def _sa_model_iter_fields(model_cls: Type) -> types.FieldIterator:
-    yield from model_cls.__table__.columns.keys()
-
+# All imports below are are optional and add support for various popular
+# libraries out of the box.
+try:
+    from .integrations import dataclasses   # noqa: F401
+except ImportError:
+    pass
 
 try:
-    # Optional pydantic support.
-    # Does not require pydantic as it's not a dependency, but if installed it
-    # will support it out of the box.
-    import pydantic
+    from .integrations import pydantic   # noqa: F401
+except ImportError:
+    pass
 
-    @field_iterator(test=lambda cls: issubclass(cls, pydantic.BaseModel))
-    def _pydantic_iter_fields(model_cls: Type) -> types.FieldIterator:
-        pydantic_model = cast(pydantic.BaseModel, model_cls)
-        yield from pydantic_model.__fields__.keys()
-
+try:
+    from .integrations import sqlalchemy   # noqa: F401
 except ImportError:
     pass

--- a/src/mappr/types.py
+++ b/src/mappr/types.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any, Callable, Dict, Iterator, Type
 
 ConverterFn = Callable[[Any], Any]
@@ -8,10 +7,10 @@ FieldIterator = Iterator[str]
 TestFn = Callable[[Type], bool]
 
 
-@dataclasses.dataclass
 class FieldIter:
-    test: TestFn
-    iter: Callable[[Type], FieldIterator]
+    def __init__(self, test: TestFn, iter_factory: Callable[[type], FieldIterator]):
+        self.test = test
+        self.iter_factory = iter_factory
 
     def can_handle(self, any_cls: Type) -> bool:
         # We need to use getattr as using self.test will call test as a method
@@ -20,4 +19,4 @@ class FieldIter:
         return getattr(self, 'test')(any_cls)
 
     def make_iterator(self, any_cls: Type) -> FieldIterator:
-        return getattr(self, 'iter')(any_cls)
+        return getattr(self, 'iter_factory')(any_cls)


### PR DESCRIPTION
v0.1.20
========


Features
--------

- python 3.6 support
  The initial versions required python 3.8 but since 3.6 is still supported for
  the next 11 months it would be good to support it as as well (especially
  since it’s not that big of a difference for the library code).


Dev tasks
---------

- Add new changelog tag: refactor
  Will be useful to see in the changelog what have been refactored since the
  last release.


Refactored
----------

- Move integrations to their own package
  Makes it easier to see what’s supported + gives a clearer separation between
  what’s the core functionality and what is an integration with 3rd party.
  **mappr** on it’s own does not depend on anything.