### PR TITLE
Release: v0.3.0

### DIFF
--- a/docs/src/examples/simple.py
+++ b/docs/src/examples/simple.py
@@ -28,8 +28,8 @@ class UserPublic:
 # mapping will be copied directly. The source type needs the have attributes
 # that match the name, otherwise an exception is raised.
 mappr.register(User, Person, mapping=dict(
-    nick=lambda obj, name: obj.username,
-    name=lambda obj, name: f"{obj.first_name} {obj.last_name}",
+    nick=lambda o: o.username,
+    name=lambda o: f"{o.first_name} {o.last_name}",
 ))
 
 # We can now create a an instance of ``User`` so we can test our converter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mappr"
-version = "0.2.3"
+version = "0.3.0"
 description = ""
 authors = ["Mateusz Klos <novopl@gmail.com>"]
 repository = "https://github.com/novopl/mappr"

--- a/src/mappr/__init__.py
+++ b/src/mappr/__init__.py
@@ -35,4 +35,4 @@ from .types import (  # noqa: F401
 # Initialize all optional integrations.
 from . import integrations  # noqa: F401, E402
 
-__version__ = '0.2.3'
+__version__ = '0.3.0'

--- a/src/mappr/conversion.py
+++ b/src/mappr/conversion.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Dict, Optional, Type, TypeVar
 
 from . import iterators, mappers, registry
 from .enums import Strategy
@@ -11,7 +11,7 @@ def convert(
     dst_type: Type[T],
     src_obj,
     strict: bool = True,
-    strategy: Strategy = Strategy.CONSTRUCTOR,
+    strategy: Optional[Strategy] = None,
 ) -> T:
     """ Convert an object to a given type.
 
@@ -29,6 +29,7 @@ def convert(
         from ``src_obj``.
     """
     converter = registry.get_converter(src_obj.__class__, dst_type, strict=strict)
+    strategy = strategy or converter.strategy
     values = {}
 
     for name in iterators.iter_fields(dst_type):

--- a/src/mappr/conversion.py
+++ b/src/mappr/conversion.py
@@ -35,7 +35,7 @@ def convert(
         mapping_fn = converter.mapping.get(name, mappers.alias(name))
 
         if mapping_fn != mappers.use_default:
-            values[name] = mapping_fn(src_obj, name)
+            values[name] = mapping_fn(src_obj)
 
     if strategy == Strategy.CONSTRUCTOR:
         return _build_by_constructor(dst_type, values)

--- a/src/mappr/mappers.py
+++ b/src/mappr/mappers.py
@@ -4,8 +4,8 @@ from . import types
 
 
 def alias(aliased_name: str) -> types.MappingFn:
-    def mapper(src_obj: Any, name: str) -> Any:
-        return getattr(src_obj, aliased_name, None)
+    def mapper(o: Any) -> Any:
+        return getattr(o, aliased_name, None)
     return mapper
 
 
@@ -51,12 +51,12 @@ def set_const(value: Any) -> types.MappingFn:
         >>> dst.num
         100
     """
-    def mapper(src_obj: Any, name: str) -> Any:
+    def mapper(o: Any) -> Any:
         return value
     return mapper
 
 
-def use_default(src_obj: Any, name: str) -> Any:
+def use_default(o: Any) -> Any:
     """ Indicate we want to use default field value  rather than value from source object
 
     Args:

--- a/src/mappr/types.py
+++ b/src/mappr/types.py
@@ -1,5 +1,6 @@
 import dataclasses
 from typing import Any, Callable, Dict, Iterator, Type
+from .enums import Strategy
 
 ConverterFn = Callable[[Any], Any]
 MappingFn = Callable[[Any], Any]
@@ -28,3 +29,4 @@ class TypeConverter:
     src_type: Type
     dst_type: Type
     mapping: FieldMapping = dataclasses.field(default_factory=dict)
+    strategy: Strategy = Strategy.CONSTRUCTOR

--- a/src/mappr/types.py
+++ b/src/mappr/types.py
@@ -2,7 +2,7 @@ import dataclasses
 from typing import Any, Callable, Dict, Iterator, Type
 
 ConverterFn = Callable[[Any], Any]
-MappingFn = Callable[[Any, str], Any]
+MappingFn = Callable[[Any], Any]
 FieldMapping = Dict[str, MappingFn]
 FieldIterator = Iterator[str]
 TestFn = Callable[[Type], bool]

--- a/tests/integrations/test_pydantic.py
+++ b/tests/integrations/test_pydantic.py
@@ -84,9 +84,9 @@ mappr.register(User, UserInternal, mapping=dict(
     pw_hash=mappr.set_const(None),
 ))
 mappr.register(User, WonkyUser, mapping=dict(
-    nick=lambda o, n: o.username,
-    first_name=lambda o, n: o.name,
-    joined_at=lambda o, n: o.created_at,
+    nick=lambda o: o.username,
+    first_name=lambda o: o.name,
+    joined_at=lambda o: o.created_at,
 ))
 
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 import pytest
 
@@ -17,8 +17,41 @@ class User:
         self.age = age
 
 
+@dataclass
+class Account:
+    name: str
+    age: str
+
+    def __init__(self):
+        super(Account, self).__init__()
+
+
 def test_raises_TypeNotSupported_if_no_iterator_registered(scoped_register):
     mappr.register(Person, User)
 
     with pytest.raises(mappr.TypeNotSupported):
         mappr.convert(User, Person(name='John', age=25))
+
+
+def test_constructor_strategy_doesnt_work_without_appropriate_ctor(scoped_register):
+    mappr.register(Person, Account)
+
+    with pytest.raises(TypeError) as exc_info:
+        mappr.convert(Account, Person(name='John', age=25))
+
+    assert 'got an unexpected keyword argument' in str(exc_info.value)
+
+
+def test_can_override_strategy_for_single_conversion(scoped_register):
+    mappr.register(Person, Account)
+
+    account = mappr.convert(
+        Account,
+        Person(name='John', age=25),
+        strategy=mappr.Strategy.SETATTR
+    )
+
+    assert asdict(account) == {
+        'name': 'John',
+        'age': 25,
+    }


### PR DESCRIPTION
v0.3.0
=======


Features
--------

- Can specify default strategy for the mapping
  Until now, you could only specify the strategy during conversion, so if you
  wanted to always use a SETATTR strategy you would have to pass it each time
  you convert something. Now you can define the strategy when registering a
  mapping and then it will be used as default for all conversions. You can
  still override the strategy directly in `convert`, but the default is now
  specified in the mapping.


Changes
-------

- The mapping functions do not take name anymore
  The name is never used anyway and is always on the other side of ‘=‘ in the
  mapping. No need to keep it and makes things longer. Getting rid of it to
  simplify the mappers slightly.